### PR TITLE
Split `/choose` command options using regex

### DIFF
--- a/commands/choose.js
+++ b/commands/choose.js
@@ -18,7 +18,7 @@ module.exports = {
         const options = interaction.options.getString("options");
         const hidden = interaction.options.getBoolean("hidden") || false;
 
-        let splitOptions = options.split(", ");
+        let splitOptions = options.split(/,\s*/gm);
 
         if (splitOptions.length === 1) {
             return interaction.reply({


### PR DESCRIPTION
The previous implementation split on a literal ", ", which still
(somehow) worked for patterns like "a,      b", but failed when
presented with a pattern not containing a space (like "a,b").  Using a
regular expression instead catches all previously caught cases, but also
matches space-free lists.

(This commit also adds a newline to the file, because apparently the code did not have that before, and my editor is set up to automatically ensure every file ends with a single newline character.  My bad.)